### PR TITLE
Wildcard routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PubSub
+
 PubSub is a Go Package for in-memory publish/subscribe.
 
 [![test and build](https://github.com/davidscottmills/pubsub/workflows/test%20and%20build/badge.svg)](https://github.com/davidscottmills/pubsub/actions?query=workflow%3A%22test+and+build%22)
@@ -39,12 +40,6 @@ func main() {
     s, err := ps.Subscribe("subject.name", handerFunc)
     defer s.Unsubscribe()
 
-    // Bound the number of concurrent handler functions by passing number
-    // of concurrent go routines that you want to allow.
-    // Subscribe to a subject
-    s, err := ps.Subscribe("subject.name", handerFunc, 10)
-    defer s.Unsubscribe()
-
     // Publish
     ps.Publish("subject.name", "Hello, world!")
 
@@ -57,6 +52,21 @@ func main() {
 }
 ```
 
+## Subject Routing
+
+Subject naming matches that of NATS.
+
+### Subject Names
+
+- All ascii alphanumeric characters except spaces/tabs and separators which are "." and ">" are allowed. Subject names can be optionally token-delimited using the dot character (.)
+- Subjects are case sensative
+
+### Subject Wildcards
+- The asterisk character (*) matches a single token at any level of the subject.
+- The greater than symbol (>), also known as the full wildcard, matches one or more tokens at the tail of a subject, and must be the last token. The wildcarded subject foo.> will match foo.bar or foo.bar.baz.1, but not foo. 
+- Wildcards must be a separate token (foo.*.baz or foo.> are syntactically valid; foo*.bar, f*o.b*r and foo> are not)
+
 ## TODO
+
 - Implement and test close or drain on PubSub
 - Implement and test errors

--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ func main() {
         fmt.Println(m.Data)
     }
 
-    // Unbounded number of go routines
     // Subscribe to a subject
     s, err := ps.Subscribe("subject.name", handerFunc)
     defer s.Unsubscribe()
 
     // Publish
-    ps.Publish("subject.name", "Hello, world!")
+    err := ps.Publish("subject.name", "Hello, world!")
 
     someStruct := struct{}{}
 

--- a/main_test.go
+++ b/main_test.go
@@ -126,6 +126,126 @@ func Test_PubSub_Multiple_Messages(t *testing.T) {
 	}
 }
 
+func Test_subjectMatches_Wildcard_Routing(t *testing.T) {
+	testData := []struct {
+		testCaseID       int
+		subscribeSubject string
+		msgSubject       string
+		expected         bool
+	}{
+		{
+			testCaseID:       1,
+			subscribeSubject: "foo.bar",
+			msgSubject:       "foo.bar",
+			expected:         true,
+		},
+		{
+			testCaseID:       2,
+			subscribeSubject: ">",
+			msgSubject:       "foo.bar",
+			expected:         true,
+		},
+		{
+			testCaseID:       3,
+			subscribeSubject: "foo.>",
+			msgSubject:       "foo.bar",
+			expected:         true,
+		},
+		{
+			testCaseID:       4,
+			subscribeSubject: "foo.>",
+			msgSubject:       "foo.bar.1234",
+			expected:         true,
+		},
+		{
+			testCaseID:       5,
+			subscribeSubject: "foo.bar.*",
+			msgSubject:       "foo.bar.1234",
+			expected:         true,
+		},
+		{
+			testCaseID:       6,
+			subscribeSubject: "foo.*.bar",
+			msgSubject:       "foo.bar.bar",
+			expected:         true,
+		},
+		{
+			testCaseID:       7,
+			subscribeSubject: "*.bar.bar",
+			msgSubject:       "foo.bar.bar",
+			expected:         true,
+		},
+		{
+			testCaseID:       8,
+			subscribeSubject: "foo.*.>",
+			msgSubject:       "foo.bar.baz.1234",
+			expected:         true,
+		},
+		{
+			testCaseID:       9,
+			subscribeSubject: "foo",
+			msgSubject:       "bar",
+			expected:         false,
+		},
+		{
+			testCaseID:       10,
+			subscribeSubject: "foo.*",
+			msgSubject:       "food.bar.baz",
+			expected:         false,
+		},
+		{
+			testCaseID:       11,
+			subscribeSubject: "foo.>",
+			msgSubject:       "food.bar.baz",
+			expected:         false,
+		},
+		{
+			testCaseID:       12,
+			subscribeSubject: "foo.bar",
+			msgSubject:       "food.bar.baz",
+			expected:         false,
+		},
+		{
+			testCaseID:       13,
+			subscribeSubject: "foo.*.*.>",
+			msgSubject:       "foo.bar.bar",
+			expected:         false,
+		},
+		{
+			testCaseID:       14,
+			subscribeSubject: "foo.*.*.>",
+			msgSubject:       "foo.bar.bar.baz.12345",
+			expected:         true,
+		},
+		{
+			testCaseID:       15,
+			subscribeSubject: "foo.*.bar.*",
+			msgSubject:       "foo.buzz.bar.fizz",
+			expected:         true,
+		},
+		{
+			testCaseID:       16,
+			subscribeSubject: "foo.*.*.fizz.>",
+			msgSubject:       "foo.buzz.bar.fizz.12345",
+			expected:         true,
+		},
+		{
+			testCaseID:       17,
+			subscribeSubject: "foo.*.*.*",
+			msgSubject:       "foo.bar.baz.buzz.bizz",
+			expected:         false,
+		},
+	}
+
+	for _, td := range testData {
+		result := subjectMatches(td.subscribeSubject, td.msgSubject)
+		if result != td.expected {
+			t.Logf("TestCaseID: %d, Expected %t, got %t", td.testCaseID, td.expected, result)
+			t.Fail()
+		}
+	}
+}
+
 func Benchmark_HelloWorld_TenSubscriptions_OneMessagesPerSubscription(b *testing.B) {
 	// Setup
 	ps := NewPubSub()


### PR DESCRIPTION
### Changes include:

- Support for wildcard routing (*,>) to match NATS subject based routing
- Subject name validation

### Breaking Changes

- Publish now returns an error when the subject name is in invalid